### PR TITLE
Feature: Bot Responds to Mentions Only

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,12 @@
+# OpenAI API Key
+OPENAI_API_KEY="your_openai_api_key"
+
+# Discord API Key
+DISCORD_API_KEY="your_discord_api_key"
+
+# MongoDB credentials
+MONGODB_URI="your_mongodb_uri"
+MONGODB_DB_NAME="your_mongodb_database_name"
+
+# Flask port
+FLASK_PORT="your_flask_port"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.egg-info/
+dist/
+build/
+*.egg
+
+# Environments
+.venv
+env/
+venv/
+ENV/
+
+# Logs
+logs/
+*.log
+
+# Database
+*.db
+
+# dotenv environment variables file
+.env
+
+# Jupyter Notebook
+.ipynb_checkpoints


### PR DESCRIPTION
This pull request introduces two main updates to the Discord bot:

1. The bot now responds only when it is mentioned in a message. Previously, the bot was responding to all messages in the channel, which could lead to unnecessary noise and potential spam. The `on_message(message)` event handler has been modified to check if the bot is mentioned in a message before processing it. If the bot is not mentioned, it simply logs the event without responding. 

2. The bot now checks if the DISCORD_API_KEY is set before attempting to connect to the Discord API. If the key is not found in the environment variables, an error message is logged and the bot stops running. If the key is found but incorrect, a discord.LoginFailure exception is raised and logged. 

These updates enhance the user experience by reducing the bot's verbosity and making its interactions more targeted and meaningful. They also improve the bot's error handling and make it easier to diagnose issues with the API key.
